### PR TITLE
fix: export NProgress for outside access  and call programmatically NProgress.start() and NProgress.done()

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,5 +72,7 @@ const NextProgress = React.memo(
 
 export default NextProgress;
 
+export { NProgress };
+
 //? Unexported type from next/dist/shared/lib/mitt.d.ts
 declare type Handler = (...evts: any[]) => void;


### PR DESCRIPTION
Users can now import NProgress directly from NextProgress without the need to reference the nprogress package separately. and call NProgress.start() and NProgress.done()
